### PR TITLE
Removing the ni-control-id

### DIFF
--- a/examples/chart_demo.html
+++ b/examples/chart_demo.html
@@ -53,14 +53,14 @@
     <div id="page-wrap">
         <h1>Waveform generator connected to a Chart</h1>
         <div id="chart div" style="position: relative;">
-            <ni-chart id="chart" ni-control-id="28" buffer-size="1000" value="[]">
+            <ni-chart id="chart" graph-ref="28" buffer-size="1000" value="[]">
                 <ni-cartesian-axis show label="Samples" show-label show-tick-labels="all" axis-position="bottom" auto-scale="sliding-window" minimum="0" maximum="1000" grid-lines show-ticks></ni-cartesian-axis>
                 <ni-cartesian-axis id="chartY" show show-ticks show-minor-ticks label="Amplitude" show-label axis-position="left" minimum="-10" maximum="10" auto-scale="none" grid-lines></ni-cartesian-axis>
                 <ni-cartesian-plot show label="Waveforms">
                     <ni-cartesian-plot-renderer line-width="1" line-stroke="#0087FF"></ni-cartesian-plot-renderer>
                 </ni-cartesian-plot>
             </ni-chart>
-            <ni-graph-tools ni-control-id='38' binding-info='{"prop":"value","sync":true}' label-id='' graph-name='28'></ni-graph-tools>
+            <ni-graph-tools binding-info='{"prop":"value","sync":true}' label-id='' graph-name='28'></ni-graph-tools>
         </div>
 
         <table>

--- a/examples/intensity.html
+++ b/examples/intensity.html
@@ -25,7 +25,7 @@
     <div id="page-wrap">
         <h1>Intensity graph</h1>
 
-        <ni-intensity-graph id="intensity1" ni-control-id="50">
+        <ni-intensity-graph id="intensity1">
           <ni-cartesian-axis id="horizontalAxis" show log-scale show-ticks show-minor-ticks show-tick-labels="all" grid-lines show-label label="Width" axis-position="bottom" minimum="1" maximum="1000" auto-scale='none'></ni-cartesian-axis>
           <ni-cartesian-axis id="verticalAxis" show log-scale show-ticks show-minor-ticks show-tick-labels="all" show-endpoints grid-lines show-label label="Height" axis-position="left"  minimum="1" maximum="1000" auto-scale='none'></ni-cartesian-axis>
           <ni-color-scale show show-tick-labels="endpoints" auto-scale="none" markers='[{"value":-3.14,"color":"rgba(255,255,255,0.25)"},{"value":0,"color":"rgba(0,0,0,1)"},{"value":3.14,"color":"rgba(255,255,255,0.25)"}]'></ni-color-scale>

--- a/examples/ligo.html
+++ b/examples/ligo.html
@@ -147,7 +147,7 @@
             This is the theoretical model:
         </p>
         <div class="theoreticalTemplate" >
-            <ni-cartesian-graph id="graph0" ni-control-id="26" value="[]">
+            <ni-cartesian-graph id="graph0" graph-ref="26" value="[]">
                 <ni-cartesian-axis show show-label show-tick-labels="none" auto-scale="exact" label="Time" axis-position="bottom"></ni-cartesian-axis>
                 <ni-cartesian-axis show show-label show-tick-labels="none" auto-scale="exact" label="Strain" axis-position="left"></ni-cartesian-axis>
                 <ni-cartesian-plot show label="Theoretical template">
@@ -175,14 +175,14 @@
                     <ni-cartesian-plot-renderer line-width="1" line-stroke="rgb(210, 180, 180)"></ni-cartesian-plot-renderer>
                 </ni-cartesian-plot>
             </ni-cartesian-graph>
-            <ni-graph-tools ni-control-id='38' graph-name='28'></ni-graph-tools>
-            <ni-plot-legend ni-control-id='36' graph-name='28'></ni-plot-legend>
+            <ni-graph-tools graph-name='28'></ni-graph-tools>
+            <ni-plot-legend graph-name='28'></ni-plot-legend>
         </div>
         <p class="paragraph">
             Amplitude spectral density:
         </p>
         <div class="asd">
-            <ni-cartesian-graph id="graph2" ni-control-id="30" value="[]">
+            <ni-cartesian-graph id="graph2" graph-ref="30" value="[]">
                 <ni-cartesian-axis show show-ticks show-minor-ticks show-label log-scale auto-scale="none" minimum="10" maximum="2048" label="Frequency (Hz)" axis-position="bottom"></ni-cartesian-axis>
                 <ni-cartesian-axis show show-ticks show-minor-ticks show-label log-scale auto-scale="none" minimum="1.0e-24" maximum="1.0e-19" label="ASD Strain" axis-position="left" format="LVSI" grid-lines></ni-cartesian-axis>
                 <!--ni-cartesian-plot label="Hanford Observatory">
@@ -193,13 +193,13 @@
                 </ni-cartesian-plot>
             </ni-cartesian-graph>
             <!-- cursors + bar-fill don't play well together -->
-            <ni-plot-legend ni-control-id='36' graph-name='30'></ni-plot-legend>
+            <ni-plot-legend graph-name='30'></ni-plot-legend>
         </div>
         <p class="paragraph">
             Whitened and [20, 300] Hz bandpass filter:
         </p>
         <div class="whitened">
-            <ni-cartesian-graph id="graph3" ni-control-id="32" value="[]">
+            <ni-cartesian-graph id="graph3" graph-ref="32" value="[]">
 
                 <ni-cartesian-axis show axis-position="bottom" show-ticks show-tick-labels="endpoints" auto-scale="none" minimum="67060" maximum="67360" label="Time" axis-position="bottom" axis-ref="xaxis1ref"></ni-cartesian-axis>
                 <ni-cartesian-axis show axis-position="bottom" show-ticks show-tick-labels="endpoints" auto-scale="none" minimum="67057" maximum="67357" label="Time" axis-position="bottom" axis-ref="xaxis2ref"></ni-cartesian-axis>
@@ -221,13 +221,13 @@
 
             </ni-cartesian-graph>
                 <!-- cursors + bar-fill don't play well together -->
-            <ni-plot-legend ni-control-id='36' graph-name='32'></ni-plot-legend>
+            <ni-plot-legend graph-name='32'></ni-plot-legend>
         </div>
         <p class="paragraph">
             The next graph is the spectrogram of the whitened signal recorded by the Handford Observatory zoomed in around the moment of the merging of the two black holes.
         </p>
         <div class="spectrogram">
-            <ni-intensity-graph id="intensity1" ni-control-id="50">
+            <ni-intensity-graph id="intensity1" graph-ref="50">
               <ni-cartesian-axis show show-ticks show-minor-ticks show-tick-labels="none" grid-lines show-label label="Time" axis-position="bottom" minimum="2300" maximum="2800" auto-scale='none'></ni-cartesian-axis>
               <ni-cartesian-axis show show-ticks show-minor-ticks show-tick-labels="none" show-endpoints grid-lines show-label label="Frequency (Hz)" axis-position="left"  minimum="0" maximum="30" auto-scale='none'></ni-cartesian-axis>
               <ni-color-scale show show-tick-labels="endpoints" auto-scale="none" markers='[{"value":-11,"color":"rgba(210, 180, 180,1)"},{"value":-6,"color":"rgba(0,0,0,1)"},{"value":-1.5,"color":"rgba(184,186,214,1)"}]'></ni-color-scale>


### PR DESCRIPTION
The ni-control-id is a LabVIEW thing. There is some work done in the WebCharts to support ni-control-id instead of graph-ref or axis-ref, but in order to make this support complete, a jqx module located in LabVIEW is required.

Some of these examples used to fail from time to time because of a race condition + the incomplete support.

Removing all the ni-control-id references from the examples to prevent the copy-paste bugs.