### PR TITLE
Fix index page and document title

### DIFF
--- a/examples/chart_demo.html
+++ b/examples/chart_demo.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <title>Demo Chart</title>
+    <title>Waveform generator connected to a Chart</title>
     <link rel="stylesheet" href="../node_modules/ni-webcharts/styles/webchartsLight.css" />
     <link rel="stylesheet" href="../node_modules/jqwidgets-scripts/jqwidgets/styles/jqx.base.css" />
     <link rel="stylesheet" href="../node_modules/jqwidgets-scripts/jqwidgets/styles/jqx.fresh.css" />

--- a/examples/graph_dark.html
+++ b/examples/graph_dark.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Webcharts Graph</title>
+    <title>Webcharts Graph Dark</title>
     <link rel="stylesheet" href="../node_modules/ni-webcharts/styles/webchartsDark.css" />
 
     <script>
@@ -32,7 +32,7 @@
     </style>
 </head>
 <body style ="background-color: #303030; color: #e0e0e0">
-    <h1>Webcharts Graph</h1>
+    <h1>Webcharts Graph Dark</h1>
 
     <h2>Arrays of numbers</h2>
     <ni-cartesian-graph id="graph1" value="[[0, 10, 200, 3, 40, 500, 6, 70, 800], [1, 20, 600, 40, 5]]">

--- a/examples/intensity.html
+++ b/examples/intensity.html
@@ -30,7 +30,7 @@
 
 <body>
     <div id="page-wrap">
-        <h1>Intensity graph</h1>
+        <h1>Intensity graph with logarithmic axes</h1>
 
         <ni-intensity-graph id="intensity1">
           <ni-cartesian-axis id="horizontalAxis" show log-scale show-ticks show-minor-ticks show-tick-labels="all" grid-lines show-label label="Width" axis-position="bottom" minimum="1" maximum="1000" auto-scale='none'></ni-cartesian-axis>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,10 @@
 
     <link rel="stylesheet" href="cards.css" />
     <meta name="viewport" content="width=device-width">
-    <title>Webcharts performance</title>
+    <title>Webcharts Drive Test</title>
   </head>
   <body>
-    <h1 style="text-align:center;">Webcharts test drive</h1>
+    <h1 style="text-align:center;">Webcharts Drive Test</h1>
     <div id="mainbox">
         <div class="card">
             <img src="line-chart.svg">

--- a/performance/chart.html
+++ b/performance/chart.html
@@ -31,7 +31,7 @@
     </style>
 </head>
 <body>
-    <h1>Webcharts Chart performance</h1>
+    <h1>Webcharts Chart performance test</h1>
 
     <ni-chart id="graph1" buffer-size="100000">
       <ni-cartesian-axis show grid-lines label="Time" axis-position="bottom"></ni-cartesian-axis>

--- a/performance/graph with cursor.html
+++ b/performance/graph with cursor.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Webcharts Graph performance test</title>
+    <title>Webcharts Graph with cursor performance test</title>
     <link rel="stylesheet" href="../node_modules/ni-webcharts/styles/webchartsLight.css" />
 
     <script>
@@ -32,7 +32,7 @@
     </style>
 </head>
 <body>
-    <h1>Webcharts Graph</h1>
+    <h1>Webcharts Graph with cursor performance test</h1>
 
     <h2>Array of numbers</h2>
     <ni-cartesian-graph id="graph1" value="[0, 10, 200, 3, 40, 500, 6, 70, 800]">

--- a/performance/graph_analogWaveform.html
+++ b/performance/graph_analogWaveform.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Webcharts Graph performance test</title>
+    <title>Webcharts Graph with AnalogWaveform performance test</title>
     <link rel="stylesheet" href="../node_modules/ni-webcharts/styles/webchartsLight.css" />
 
     <script>
@@ -32,7 +32,7 @@
     </style>
 </head>
 <body>
-    <h2>AnalogWaveform Graph</h2>
+    <h2>Webcharts Graph with AnalogWaveform performance test</h2>
     <ni-cartesian-graph id="graph" value="[]">
       <ni-cartesian-axis show grid-lines label="Time" axis-position="bottom"  format="LVTime"></ni-cartesian-axis>
       <ni-cartesian-axis show grid-lines label="Amplitude" axis-position="left" ></ni-cartesian-axis>

--- a/performance/scatter_graph.html
+++ b/performance/scatter_graph.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Webcharts Graph performance test</title>
+    <title>Webcharts Scatter Graph performance test</title>
     <link rel="stylesheet" href="../node_modules/ni-webcharts/styles/webchartsLight.css" />
 
     <script>
@@ -32,7 +32,7 @@
     </style>
 </head>
 <body>
-    <h1>Webcharts Graph performance</h1>
+    <h1>Webcharts Scatter Graph performance</h1>
 
     <ni-cartesian-graph id="graph1" value="[]">
       <ni-cartesian-axis show grid-lines label="Time" axis-position="bottom" ></ni-cartesian-axis>


### PR DESCRIPTION
The title was really misleading especially when pasting a link to this page in an editor which was pulling the "Webcharts performance" title automatically.